### PR TITLE
Fixes #8 - Handle bool type and None in json conversion

### DIFF
--- a/src/fjson/main.py
+++ b/src/fjson/main.py
@@ -68,12 +68,16 @@ def _value_to_string2(value, indent, separators, level):
 
 
 def _value_to_string(value, float_fmt):
-    if isinstance(value, dict):
+    if value is None:
+        return _tostring_none(value)
+    elif isinstance(value, dict):
         return _dict_to_strings(value, float_fmt)
     elif isinstance(value, list):
         return _list_to_strings(value, float_fmt)
     elif isinstance(value, str):
         return _tostring_str(value)
+    elif isinstance(value, bool):
+        return _tostring_bool(value)
     elif isinstance(value, int):
         return _tostring_int(value)
     elif isinstance(value, float):
@@ -116,3 +120,11 @@ def _tostring_float(val, fmt):
     if fmt is None:
         return str(val)
     return f"{val:{fmt}}"
+
+
+def _tostring_bool(val):
+    return "true" if val else "false"
+
+
+def _tostring_none(val):
+    return "null"

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -4,7 +4,7 @@ import math
 import numpy as np
 import pytest
 
-import fjson
+import src.fjson.main as fjson
 
 
 def test_simple():
@@ -52,6 +52,15 @@ def test_separators():
 
     ref = json.dumps(a, indent=2, separators=("X", "Y"))
     string = fjson.dumps(a, indent=2, separators=("X", "Y"))
+    assert ref == string
+
+
+def test_json_datatypes():
+    a = {"string_type": "some string", "number_type": 10, "object_type": {"a": "x", "b": "y", "c": "z"}, "array_type": ["a", "b", "c"], "bool_type_true": True, "bool_type_false": False, "null_type": None}
+    ref = json.dumps(a)
+    string = fjson.dumps(a)
+    print(ref)
+    print(string)
     assert ref == string
 
 

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -56,7 +56,15 @@ def test_separators():
 
 
 def test_json_datatypes():
-    a = {"string_type": "some string", "number_type": 10, "object_type": {"a": "x", "b": "y", "c": "z"}, "array_type": ["a", "b", "c"], "bool_type_true": True, "bool_type_false": False, "null_type": None}
+    a = {
+        "string_type": "some string",
+        "number_type": 10,
+        "object_type": {"a": "x", "b": "y", "c": "z"},
+        "array_type": ["a", "b", "c"],
+        "bool_type_true": True,
+        "bool_type_false": False,
+        "null_type": None,
+    }
     ref = json.dumps(a)
     string = fjson.dumps(a)
     print(ref)


### PR DESCRIPTION
This fixes issue #8, where bool and None values aren't handled during json conversion. I added a test covering this issue, and I've updated the test code to import the source code directly rather than testing against the published library.